### PR TITLE
Fix development logs being wrapped when LogStruct is disabled

### DIFF
--- a/lib/log_struct/monkey_patches/active_support/tagged_logging/formatter.rb
+++ b/lib/log_struct/monkey_patches/active_support/tagged_logging/formatter.rb
@@ -27,8 +27,15 @@ module ActiveSupport
       # plain strings in a Hash under a `msg` key.
       # The data is then passed to our custom log formatter that transforms it
       # into a JSON string before logging.
+      #
+      # IMPORTANT: This only applies when LogStruct is enabled. When disabled,
+      # we preserve the original Rails logging behavior to avoid wrapping
+      # messages in hashes (which would break default Rails log formatting).
       sig { params(severity: T.any(String, Symbol), time: Time, progname: T.untyped, data: T.untyped).returns(String) }
       def call(severity, time, progname, data)
+        # Skip hash wrapping when LogStruct is disabled to preserve default Rails behavior
+        return super unless ::LogStruct.enabled?
+
         # Convert data to a hash if it's not already one
         data = {message: data.to_s} unless data.is_a?(Hash)
 

--- a/test/log_struct/configuration_test.rb
+++ b/test/log_struct/configuration_test.rb
@@ -198,6 +198,26 @@ module LogStruct
       LogStruct.config.filters.filter_matchers = T.must(original_matchers)
     end
 
+    # Test that development server process is DISABLED by default
+    # (development is not in enabled_environments by default)
+    def test_disabled_for_development_server_with_default_environments
+      LogStruct.config.enabled = true
+      # Use default enabled_environments: [:test, :production]
+      LogStruct.config.enabled_environments = [:test, :production]
+
+      original_argv = ::ARGV.dup
+      ::ARGV.replace(["server"])
+
+      Rails.stub(:env, ActiveSupport::StringInquirer.new("development")) do
+        LogStruct.set_enabled_from_rails_env!
+
+        assert_not LogStruct.config.enabled,
+          "LogStruct should be DISABLED for development server (development not in enabled_environments)"
+      end
+    ensure
+      ::ARGV.replace(original_argv) if defined?(original_argv)
+    end
+
     # Test server process detection
     def test_enabled_for_server_process_in_production
       LogStruct.config.enabled = false

--- a/test/log_struct/monkey_patches/tagged_logging_formatter_test.rb
+++ b/test/log_struct/monkey_patches/tagged_logging_formatter_test.rb
@@ -1,0 +1,65 @@
+# typed: true
+# frozen_string_literal: true
+
+require "test_helper"
+
+module LogStruct
+  module MonkeyPatches
+    class TaggedLoggingFormatterTest < ActiveSupport::TestCase
+      setup do
+        @original_config = LogStruct.config.dup
+        @output = StringIO.new
+        @logger = Logger.new(@output)
+        @tagged_logger = ActiveSupport::TaggedLogging.new(@logger)
+      end
+
+      teardown do
+        LogStruct.configuration = @original_config
+      end
+
+      def test_preserves_original_rails_behavior_when_disabled
+        LogStruct.config.enabled = false
+
+        @tagged_logger.info("Test message")
+
+        output = @output.string
+
+        assert_includes output, "Test message"
+        refute_includes output, "message:"
+        refute_includes output, "{"
+      end
+
+      def test_wraps_messages_in_hash_when_enabled
+        LogStruct.config.enabled = true
+
+        @tagged_logger.info("Test message")
+
+        output = @output.string
+
+        assert_includes output, "message"
+      end
+
+      def test_passes_through_hash_data_when_enabled
+        LogStruct.config.enabled = true
+
+        @tagged_logger.info({event: "test", data: "value"})
+
+        output = @output.string
+
+        assert_includes output, "event"
+        assert_includes output, "data"
+      end
+
+      def test_passes_through_hash_data_when_disabled
+        LogStruct.config.enabled = false
+
+        @tagged_logger.info({event: "test", data: "value"})
+
+        output = @output.string
+
+        assert_includes output, "event"
+        assert_includes output, "data"
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Fixed the TaggedLogging formatter monkey patch to check `LogStruct.enabled?` before wrapping messages in hashes
- When LogStruct is disabled (default in development), log messages now preserve their original Rails format

## Problem

When adding the LogStruct gem to a Rails 8.1 app without any configuration, development logs were appearing as `{message: "..."}` instead of plain text. This was because the `FormatterExtension` monkey patch was unconditionally wrapping all string messages in hashes, regardless of whether LogStruct was enabled.

## Solution

Added an early return check in the `FormatterExtension#call` method to skip hash wrapping when LogStruct is disabled, preserving the original Rails logging behavior in development.

## Test plan

- [x] Added unit tests for the TaggedLogging formatter conditional behavior
- [x] Added configuration test for development server scenario
- [x] All existing Ruby tests pass
- [x] All Rails integration tests pass
- [x] Typecheck passes
- [x] Lint passes

Fixes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)