### PR TITLE
Fix Rails main integration tests

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -48,7 +48,7 @@ jobs:
       - name: Enable pnpm cache
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'pnpm'
           cache-dependency-path: 'docs/pnpm-lock.yaml'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -34,7 +34,7 @@ jobs:
       - name: Enable pnpm cache
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
           cache-dependency-path: |
             pnpm-lock.yaml
@@ -107,7 +107,7 @@ jobs:
       - name: Setup Node.js (docs)
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -117,7 +117,7 @@ jobs:
       - name: Enable pnpm cache (docs)
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
           cache-dependency-path: docs/pnpm-lock.yaml
 

--- a/lib/log_struct/semantic_logger/setup.rb
+++ b/lib/log_struct/semantic_logger/setup.rb
@@ -221,6 +221,12 @@ module LogStruct
         # Replace Rails.logger
         Rails.logger = logger
 
+        # Rails assigns ActiveSupport::LogSubscriber.logger once during boot
+        # (in the active_support.set_log_subscriber_logger initializer), so log
+        # subscribers such as Lograge keep writing to the original boot logger
+        # unless this reference is updated along with Rails.logger.
+        ActiveSupport::LogSubscriber.logger = logger
+
         # Also replace various component loggers
         ActiveRecord::Base.logger = logger if defined?(ActiveRecord::Base)
         ActionController::Base.logger = logger if defined?(ActionController::Base)

--- a/rails_test_app/create_app.rb
+++ b/rails_test_app/create_app.rb
@@ -356,7 +356,12 @@ unless File.read(boot_path).include?("LOGSTRUCT_SIMPLECOV_BOOT")
         SimpleCov.start do
           root_path = File.expand_path('../../..', __dir__)
           coverage_dir File.join(root_path, 'coverage_rails')
-          add_filter '/rails_test_app/'
+          # SimpleCov >= 1.0 deprecated `add_filter` in favor of `skip`
+          if SimpleCov.respond_to?(:skip)
+            SimpleCov.skip '/rails_test_app/'
+          else
+            SimpleCov.add_filter '/rails_test_app/'
+          end
           enable_coverage :branch
           primary_coverage :branch
         end

--- a/rails_test_app/templates/test/integration/logging_integration_test.rb
+++ b/rails_test_app/templates/test/integration/logging_integration_test.rb
@@ -4,6 +4,13 @@
 require "test_helper"
 
 class LoggingIntegrationTest < ActionDispatch::IntegrationTest
+  # Rails assigns ActiveSupport::LogSubscriber.logger once during boot, so log
+  # subscribers (Lograge, Active Record, Action Controller) write to that
+  # reference rather than looking up Rails.logger on each event.
+  def test_log_subscribers_use_the_logstruct_logger
+    assert_kind_of LogStruct::SemanticLogger::Logger, ActiveSupport::LogSubscriber.logger
+  end
+
   # Basic test to ensure the Rails app is working
   def test_healthcheck_works
     get "/health"

--- a/rails_test_app/templates/test/test_helper.rb
+++ b/rails_test_app/templates/test/test_helper.rb
@@ -7,7 +7,15 @@ require "debug"
 require "open3"
 require "timeout"
 
-unless SimpleCov.running
+# SimpleCov >= 1.0 replaced the `running` accessor with `active_session?`
+simplecov_started =
+  if SimpleCov.respond_to?(:active_session?)
+    SimpleCov.active_session?
+  else
+    SimpleCov.running
+  end
+
+unless simplecov_started
   SimpleCov.formatters = [
     SimpleCov::Formatter::HTMLFormatter,
     SimpleCov::Formatter::JSONFormatter
@@ -19,7 +27,12 @@ unless SimpleCov.running
     gem_path = File.expand_path("../../../../", __FILE__)
     SimpleCov.root(gem_path)
 
-    add_filter "rails_test_app"
+    # SimpleCov >= 1.0 deprecated `add_filter` in favor of `skip`
+    if SimpleCov.respond_to?(:skip)
+      SimpleCov.skip "rails_test_app"
+    else
+      SimpleCov.add_filter "rails_test_app"
+    end
 
     coverage_dir "coverage_rails"
 


### PR DESCRIPTION
The nightly **Rails Main** workflow has been failing since early August. Two separate problems:

### 1. SimpleCov 1.x API changes (the crash CI actually hit)

SimpleCov 1.0 replaced the `running` accessor with `active_session?` and deprecated `add_filter` in favor of `skip`. The Rails test app's `test_helper.rb` calls `SimpleCov.running`, so it died with `NoMethodError` before a single test loaded:

```
test/test_helper.rb:10:in '<top (required)>': undefined method 'running' for module SimpleCov (NoMethodError)
```

Both call sites now pick whichever API the installed SimpleCov provides, so the pinned-version jobs (SimpleCov 0.22) keep working.

### 2. Lograge request logs bypassing LogStruct's appenders

Rails main assigns `ActiveSupport::LogSubscriber.logger` once during boot (the `active_support.set_log_subscriber_logger` initializer) rather than falling back to `Rails.logger` on each event. When LogStruct swapped in its own `Rails.logger`, log subscribers such as Lograge kept writing to the original boot `BroadcastLogger`, so request logs never reached the LogStruct appenders and four request-logging tests failed.

`replace_rails_logger` now updates that reference alongside `Rails.logger`. The initializer ordering that decides this isn't guaranteed, which is why it only reproduced on a freshly generated app — exactly what CI builds every run — and not on a locally cached one.

A regression test asserts the log subscriber logger is LogStruct's, so this is caught on every Rails version rather than only in the nightly job.

### Verification

- Fresh Rails main app (`FORCE_RECREATE=true RAILS_VERSION=latest`): 41 tests, 0 failures — reproduced the 4 failures beforehand and confirmed they're gone.
- Fresh Rails 7.1.6 app: 41 tests, 0 failures — no regression on pinned versions.
- `task ci`: passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Rails log subscribers now consistently use the configured Semantic Logger, improving logging consistency across Rails applications.

* **Tests**
  * Added integration coverage to verify Rails log subscribers use the expected logger.

* **Chores**
  * Improved test coverage configuration compatibility across supported SimpleCov versions.
  * Updated documentation and testing workflows to use Node.js 22 for improved tooling consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->