### PR TITLE
Pin pnpm version in CI

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: latest
+          version: 10.18.3
 
       - name: Enable pnpm cache
         uses: actions/setup-node@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: latest
+          version: 10.18.3
 
       - name: Enable pnpm cache
         uses: actions/setup-node@v4
@@ -112,7 +112,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: latest
+          version: 10.18.3
 
       - name: Enable pnpm cache (docs)
         uses: actions/setup-node@v4


### PR DESCRIPTION
Follow-up to #11. The `Lint` and `Next.js Site Tests` jobs have been failing independently of the Rails work.

### Cause

Both workflows asked pnpm's setup action for `version: latest`, so CI silently jumped to pnpm 11 while local development stays on 10.18.3. pnpm 11 [removed `onlyBuiltDependencies`](https://pnpm.io/blog/releases/11.0) in favor of a new `allowBuilds` map, which means the approval list already committed in `docs/pnpm-workspace.yaml`:

```yaml
onlyBuiltDependencies:
  - '@tailwindcss/oxide'
  - sharp
  - unrs-resolver
```

was no longer a recognized setting. pnpm 11 then treated those same three packages as unapproved and hard-failed every install with `ERR_PNPM_IGNORED_BUILDS`.

So this was never a missing approval — the approvals were there, under a name the new major stopped reading.

### Fix

Pin pnpm to 10.18.3, the version used locally. CI becomes reproducible and verifies what developers actually run, instead of drifting onto a new major on its own.

Migrating to pnpm 11 instead would mean rewriting that config as `allowBuilds` **and** upgrading local Node first — pnpm 11 requires Node >= 22.13 and this machine runs 22.6.0. Worth doing deliberately, not as a side effect of a CI fix.

### Verification

Every step in both jobs was run locally, including the ones that never got past the install:

| Step | Result |
| --- | --- |
| `pnpm install --frozen-lockfile` (root + docs) | pass |
| CSpell dictionary generation + spellcheck | pass |
| Changelog version check | pass |
| Prettier `--check` | pass |
| `tapioca gems --verify` / `dsl --verify` | pass, no RBI drift |
| RuboCop, Sorbet typecheck | pass |
| jscpd | pass, 0 clones |
| Struct export, `tsc --noEmit`, docs Jest suite | pass, 28 tests |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized the package manager version used by documentation deployment and testing workflows.
  * Improved build and verification consistency by using a fixed package manager version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->